### PR TITLE
fix: invalid naming convention rule

### DIFF
--- a/ts-recommended.js
+++ b/ts-recommended.js
@@ -63,7 +63,7 @@ module.exports = {
       },
       {
         selector: ['objectLiteralProperty', 'typeProperty', 'parameterProperty'],
-        format: [null],
+        format: null,
       },
       {
         selector: 'class',


### PR DESCRIPTION
ESLint: 8.31.0 cannot process the `@typescript-eslint/naming-convention` rule, the `format` option allows either an array of strings or `null`, but not an array of null.

```
Error: .eslintrc.js » @codingsans/eslint-config/ts-recommended:
	Configuration for rule "@typescript-eslint/naming-convention" is invalid:
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value null should be string.
	Value null should be equal to one of the allowed values.
	Value [null] should be null.
	Value [null] should match exactly one schema in oneOf.
	Value {"selector":["objectLiteralProperty","typeProperty","parameterProperty"],"format":[null]} should match exactly one schema in oneOf.
```